### PR TITLE
feat: show immunity cooldown in shop menu

### DIFF
--- a/bot/handlers/game/commands.py
+++ b/bot/handlers/game/commands.py
@@ -1351,6 +1351,7 @@ async def pidorshop_cmd(update: Update, context: GECallbackContext):
     """Открыть магазин пидор-койнов с интерактивным меню"""
     from bot.handlers.game.shop_helpers import create_shop_keyboard, format_shop_menu_message
     from bot.handlers.game.shop_service import get_active_effects
+    from bot.handlers.game.config import get_config
 
     logger.info(f"pidorshop_cmd started for chat {update.effective_chat.id}, user {context.tg_user.id}")
 
@@ -1361,10 +1362,11 @@ async def pidorshop_cmd(update: Update, context: GECallbackContext):
     # Получаем информацию об активных эффектах
     current_dt = current_datetime()
     current_date = current_dt.date()
+    config = get_config(update.effective_chat.id)
 
     active_effects = get_active_effects(
         context.db_session, context.game.id, context.tg_user.id,
-        current_date
+        current_date, immunity_cooldown_days=config.constants.immunity_cooldown_days
     )
 
     # Создаём клавиатуру магазина с owner_user_id для проверки прав и информацией об активных эффектах
@@ -2577,6 +2579,7 @@ async def handle_shop_predict_cancel_callback(update: Update, context: GECallbac
     from bot.handlers.game.shop_service import get_active_effects
     from bot.handlers.game.prediction_service import delete_prediction_draft
     from bot.handlers.game.text_static import SHOP_ERROR_NOT_YOUR_SHOP
+    from bot.handlers.game.config import get_config
 
     query = update.callback_query
 
@@ -2623,9 +2626,10 @@ async def handle_shop_predict_cancel_callback(update: Update, context: GECallbac
     balance = get_balance(context.db_session, context.game.id, context.tg_user.id)
 
     # Получаем информацию об активных эффектах
+    config = get_config(update.effective_chat.id)
     active_effects = get_active_effects(
         context.db_session, context.game.id, context.tg_user.id,
-        current_date
+        current_date, immunity_cooldown_days=config.constants.immunity_cooldown_days
     )
 
     # Создаём клавиатуру магазина
@@ -2652,6 +2656,7 @@ async def handle_shop_back_callback(update: Update, context: GECallbackContext):
     from bot.handlers.game.shop_helpers import parse_shop_callback_data, create_shop_keyboard, format_shop_menu_message
     from bot.handlers.game.shop_service import get_active_effects
     from bot.handlers.game.text_static import SHOP_ERROR_NOT_YOUR_SHOP
+    from bot.handlers.game.config import get_config
 
     query = update.callback_query
 
@@ -2684,9 +2689,10 @@ async def handle_shop_back_callback(update: Update, context: GECallbackContext):
     current_dt = current_datetime()
     current_date = current_dt.date()
 
+    config = get_config(update.effective_chat.id)
     active_effects = get_active_effects(
         context.db_session, context.game.id, context.tg_user.id,
-        current_date
+        current_date, immunity_cooldown_days=config.constants.immunity_cooldown_days
     )
 
     # Создаём клавиатуру магазина

--- a/bot/handlers/game/shop_helpers.py
+++ b/bot/handlers/game/shop_helpers.py
@@ -137,9 +137,18 @@ def create_shop_keyboard(owner_user_id: int, chat_id: int, active_effects: dict 
             elif item['callback_data'] == 'shop_predict' and active_effects.get('prediction_exists'):
                 is_active = True
 
+        # Проверяем кулдаун иммунитета для кнопки
+        is_cooldown = (
+            active_effects
+            and item['callback_data'] == 'shop_immunity'
+            and active_effects.get('immunity_on_cooldown')
+        )
+
         # Формируем текст кнопки с индикатором активности
         if is_active:
             button_text = f"✅ {item['name']} - {item['price']} 🪙"
+        elif is_cooldown:
+            button_text = f"⏳ {item['name']} - {item['price']} 🪙"
         elif item['price'] is None:
             # Для действий без цены (передача, банк)
             button_text = item['name']
@@ -390,6 +399,9 @@ def format_shop_menu_message(balance: int, chat_id: int, user_name: str = None, 
             if item['callback_data'] == 'shop_immunity' and active_effects.get('immunity_active'):
                 date = active_effects.get('immunity_date', '')
                 status_info = f"\n✅ _Активна на {escape_markdown2(date)}_"
+            elif item['callback_data'] == 'shop_immunity' and active_effects.get('immunity_on_cooldown'):
+                until = active_effects.get('immunity_cooldown_until', '')
+                status_info = f"\n⏳ _Кулдаун до {escape_markdown2(until)}_"
             elif item['callback_data'] == 'shop_double' and active_effects.get('double_chance_bought_today'):
                 status_info = "\n✅ _Уже куплен на завтра_"
             elif item['callback_data'] == 'shop_predict' and active_effects.get('prediction_exists'):

--- a/bot/handlers/game/shop_service.py
+++ b/bot/handlers/game/shop_service.py
@@ -473,7 +473,7 @@ def create_prediction(db_session, game_id: int, user_id: int, predicted_user_ids
     return True, "success", commission
 
 
-def get_active_effects(db_session, game_id: int, user_id: int, current_date: date) -> dict:
+def get_active_effects(db_session, game_id: int, user_id: int, current_date: date, immunity_cooldown_days: int = 7) -> dict:
     """
     Получить информацию об активных эффектах пользователя.
 
@@ -523,9 +523,22 @@ def get_active_effects(db_session, game_id: int, user_id: int, current_date: dat
     )
     prediction_exists = db_session.exec(stmt).first() is not None
 
+    # Проверяем кулдаун покупателя (только если защита не активна на завтра)
+    immunity_on_cooldown = False
+    immunity_cooldown_until = None
+    if not immunity_active and effect.immunity_last_used:
+        last_used_date = effect.immunity_last_used.date() if isinstance(effect.immunity_last_used, datetime) else effect.immunity_last_used
+        cooldown_end = last_used_date + timedelta(days=immunity_cooldown_days)
+        if current_date < cooldown_end:
+            immunity_on_cooldown = True
+            from bot.handlers.game.shop_helpers import format_date_readable
+            immunity_cooldown_until = format_date_readable(cooldown_end.year, cooldown_end.timetuple().tm_yday)
+
     return {
         'immunity_active': immunity_active,
         'immunity_date': immunity_date,
+        'immunity_on_cooldown': immunity_on_cooldown,
+        'immunity_cooldown_until': immunity_cooldown_until,
         'double_chance_bought_today': double_chance_bought_today,
         'prediction_exists': prediction_exists
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,7 @@ def mock_shop_effects(request, mocker):
     mock_effect = MagicMock()
     mock_effect.immunity_until = None
     mock_effect.double_chance_until = None
+    mock_effect.immunity_last_used = None
     # Патчим в обоих местах - в shop_service и в game_effects_service
     mocker.patch('bot.handlers.game.shop_service.get_or_create_player_effects', return_value=mock_effect)
     mocker.patch('bot.handlers.game.game_effects_service.get_or_create_player_effects', return_value=mock_effect)


### PR DESCRIPTION
When buyer's immunity cooldown is active, shop menu now shows ⏳ on the button and "Кулдаун до <date>" status text — same UX as double chance "already bought" indicator. Fixes confusion where cooldown was invisible.