### PR TITLE
feat: birthday bonus — x4 selection chance on player's birthday

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,6 @@ terraform.rc
 .codeassistant
 *.code-workspace
 # vibe/
+
+# Локальные данные ДР (содержат tg_id и ДР реальных людей)
+scripts/birthdays.local.json

--- a/bot/app/models.py
+++ b/bot/app/models.py
@@ -23,6 +23,8 @@ class TGUser(SQLModel, table=True):
     last_name: Optional[str]
     lang_code: str = 'en'
     is_blocked: bool = False
+    birth_month: Optional[int] = Field(default=None)
+    birth_day: Optional[int] = Field(default=None)
 
     games: List['Game'] = Relationship(back_populates="players", link_model=GamePlayer)
     game_results: List['GameResult'] = Relationship(

--- a/bot/dispatcher.py
+++ b/bot/dispatcher.py
@@ -12,6 +12,7 @@ from bot.handlers.about.commands import about_cmd
 from bot.handlers.db.handlers import open_db_session, \
     tg_user_middleware_handler, close_db_session_handler
 from bot.handlers.game.commands import pidor_cmd, pidorules_cmd, pidoreg_cmd, \
+    pidorbirthday_cmd, \
     pidorunreg_cmd, pidorremove_cmd, pidorstats_cmd, pidorall_cmd, pidorme_cmd, \
     pidoryearresults_cmd, pidoregmany_cmd, pidormissed_cmd, pidorfinal_cmd, \
     pidorfinalstatus_cmd, handle_vote_callback, pidorfinalclose_cmd, \
@@ -91,6 +92,7 @@ def init_dispatcher(application: Application, db_engine):
     application.add_handler(
         CommandHandler('pidorules', pidorules_cmd, filters=ne))
     application.add_handler(CommandHandler('pidoreg', pidoreg_cmd, filters=ne))
+    application.add_handler(CommandHandler('pidorbirthday', pidorbirthday_cmd, filters=ne))
     application.add_handler(CommandHandler('pidoregmany', pidoregmany_cmd, filters=ne))
     application.add_handler(CommandHandler('pidorunreg', pidorunreg_cmd, filters=ne))
     application.add_handler(CommandHandler('pidorremove', pidorremove_cmd, filters=ne))

--- a/bot/handlers/game/commands.py
+++ b/bot/handlers/game/commands.py
@@ -672,9 +672,11 @@ def _parse_birthday(text: str) -> tuple[int, int] | None:
     return month, day
 
 
-@ensure_game
 async def pidorbirthday_cmd(update: Update, context: GECallbackContext):
-    """Установить/очистить/посмотреть день рождения текущего пользователя."""
+    """Установить/очистить/посмотреть день рождения текущего пользователя.
+
+    Установка ДР не требует наличия игры — это персональная настройка юзера.
+    """
     from bot.handlers.game.text_static import (
         BIRTHDAY_SET, BIRTHDAY_CLEARED, BIRTHDAY_INVALID,
         BIRTHDAY_INFO_SET, BIRTHDAY_INFO_NONE, BIRTHDAY_DISABLED,

--- a/bot/handlers/game/commands.py
+++ b/bot/handlers/game/commands.py
@@ -306,8 +306,13 @@ async def pidor_cmd(update: Update, context: GECallbackContext):
         immunity_enabled = is_immunity_enabled(current_dt)
 
         # Выбираем победителя с учётом всех эффектов
+        birthday_multiplier = (
+            config.constants.birthday_bonus_multiplier
+            if config.constants.birthday_enabled else 1
+        )
         selection_result = select_winner_with_effects(
-            context.db_session, context.game.id, players, current_date, immunity_enabled
+            context.db_session, context.game.id, players, current_date,
+            immunity_enabled, birthday_multiplier=birthday_multiplier,
         )
 
         # Если все игроки защищены - отправляем специальное сообщение
@@ -429,6 +434,22 @@ async def pidor_cmd(update: Update, context: GECallbackContext):
             logger.debug("Sending year results announcement")
             await update.effective_chat.send_message(YEAR_RESULTS_ANNOUNCEMENT.format(year=cur_year), parse_mode="MarkdownV2")
 
+        # Анонс именинников (если есть и фича включена)
+        if selection_result.birthday_players:
+            from html import escape as html_escape
+            from bot.handlers.game.text_static import (
+                BIRTHDAY_ANNOUNCEMENT_SINGLE, BIRTHDAY_ANNOUNCEMENT_MULTIPLE
+            )
+            names = ", ".join(html_escape(p.full_username()) for p in selection_result.birthday_players)
+            template = (BIRTHDAY_ANNOUNCEMENT_SINGLE
+                        if len(selection_result.birthday_players) == 1
+                        else BIRTHDAY_ANNOUNCEMENT_MULTIPLE)
+            await update.effective_chat.send_message(
+                template.format(names=names, mult=birthday_multiplier),
+                parse_mode="HTML"
+            )
+            await asyncio.sleep(config.constants.game_result_time_delay)
+
         logger.debug("Sending stage 1 message")
         await update.effective_chat.send_message(random.choice(stage1.phrases))
         await asyncio.sleep(config.constants.game_result_time_delay)
@@ -459,6 +480,13 @@ async def pidor_cmd(update: Update, context: GECallbackContext):
             from html import escape as html_escape
             stage4_message += f"\n\n🎲 <b>{html_escape(winner.full_username())}</b> использовал(а) двойной шанс и победил(а)! Эффект израсходован."
             logger.info(f"Double chance was used by winner {winner.id} ({winner.full_username()})")
+
+        # Добавить плашку победы в свой ДР
+        if selection_result.had_birthday_bonus:
+            from html import escape as html_escape
+            from bot.handlers.game.text_static import BIRTHDAY_WIN_SUFFIX
+            stage4_message += BIRTHDAY_WIN_SUFFIX.format(username=html_escape(winner.full_username()))
+            logger.info(f"Birthday bonus triggered for winner {winner.id} ({winner.full_username()})")
 
         # Добавить информацию о предсказаниях (если есть)
         if predictions_results:
@@ -624,6 +652,75 @@ async def pidoregmany_cmd(update: Update, context: GECallbackContext):
         except Exception:
             logger.exception("Exception with user {}".format(user_id))
             await update.effective_message.reply_markdown_v2('Хуйня с {}'.format(user_id))
+
+
+def _parse_birthday(text: str) -> tuple[int, int] | None:
+    """Парсит 'DD.MM' → (month, day). Возвращает None если невалидно."""
+    parts = text.replace('-', '.').replace('/', '.').split('.')
+    if len(parts) != 2:
+        return None
+    try:
+        day = int(parts[0])
+        month = int(parts[1])
+    except ValueError:
+        return None
+    # Используем 2024 (високосный) — чтобы 29.02 считалось валидным
+    try:
+        datetime(2024, month, day)
+    except ValueError:
+        return None
+    return month, day
+
+
+@ensure_game
+async def pidorbirthday_cmd(update: Update, context: GECallbackContext):
+    """Установить/очистить/посмотреть день рождения текущего пользователя."""
+    from bot.handlers.game.text_static import (
+        BIRTHDAY_SET, BIRTHDAY_CLEARED, BIRTHDAY_INVALID,
+        BIRTHDAY_INFO_SET, BIRTHDAY_INFO_NONE, BIRTHDAY_DISABLED,
+    )
+
+    config = get_config(update.effective_chat.id)
+    if not config.constants.birthday_enabled:
+        await update.effective_message.reply_text(BIRTHDAY_DISABLED)
+        return
+
+    args = update.message.text.split(maxsplit=1)
+    user = context.tg_user
+
+    if len(args) < 2:
+        # Показать текущее
+        if user.birth_month and user.birth_day:
+            date_str = f"{user.birth_day:02d}.{user.birth_month:02d}"
+            await update.effective_message.reply_text(BIRTHDAY_INFO_SET.format(date=date_str))
+        else:
+            await update.effective_message.reply_text(BIRTHDAY_INFO_NONE)
+        return
+
+    arg = args[1].strip().lower()
+
+    if arg in ('clear', 'сброс', 'очистить', 'удалить', '-'):
+        user.birth_month = None
+        user.birth_day = None
+        context.db_session.add(user)
+        context.db_session.commit()
+        await update.effective_message.reply_text(BIRTHDAY_CLEARED)
+        return
+
+    parsed = _parse_birthday(arg)
+    if parsed is None:
+        await update.effective_message.reply_text(BIRTHDAY_INVALID)
+        return
+
+    month, day = parsed
+    user.birth_month = month
+    user.birth_day = day
+    context.db_session.add(user)
+    context.db_session.commit()
+    date_str = f"{day:02d}.{month:02d}"
+    await update.effective_message.reply_text(
+        BIRTHDAY_SET.format(date=date_str, mult=config.constants.birthday_bonus_multiplier)
+    )
 
 
 @ensure_game

--- a/bot/handlers/game/config.py
+++ b/bot/handlers/game/config.py
@@ -44,6 +44,10 @@ class GameConstants:
             toast_enabled: Включены ли тосты (по умолчанию: True)
             totalizator_enabled: Включён ли тотализатор (по умолчанию: False)
             coin_swap_enabled: Включён ли своп монет при self-pidor из bottom-N (по умолчанию: False)
+            birthday_enabled: Включён ли бонус именинника (по умолчанию: True)
+
+        Прочее:
+            birthday_bonus_multiplier: Множитель шанса стать пидором в свой ДР (по умолчанию: 4)
     """
     # Цены
     immunity_price: int = 10
@@ -81,6 +85,10 @@ class GameConstants:
     toast_enabled: bool = True
     totalizator_enabled: bool = False
     coin_swap_enabled: bool = False
+    birthday_enabled: bool = True
+
+    # Множитель попадания в пул для именинника
+    birthday_bonus_multiplier: int = 4
 
 
 @dataclass
@@ -294,6 +302,8 @@ def get_config(chat_id: int) -> ChatConfig:
         'toast_price': global_config.defaults.toast_price,
         'toast_enabled': global_config.defaults.toast_enabled,
         'totalizator_enabled': global_config.defaults.totalizator_enabled,
+        'birthday_enabled': global_config.defaults.birthday_enabled,
+        'birthday_bonus_multiplier': global_config.defaults.birthday_bonus_multiplier,
     }
 
     # Применяем переопределения для конкретного чата

--- a/bot/handlers/game/game_effects_service.py
+++ b/bot/handlers/game/game_effects_service.py
@@ -46,22 +46,49 @@ def filter_protected_players(
     return unprotected_players, protected_players
 
 
+def is_player_birthday(player: TGUser, current_date: date) -> bool:
+    """Проверяет, что сегодня у игрока день рождения.
+
+    29 февраля в невисокосный год считаем за 28.02 — иначе человек никогда
+    не получит бонус.
+    """
+    month = getattr(player, 'birth_month', None)
+    day = getattr(player, 'birth_day', None)
+    if month is None or day is None:
+        return False
+
+    if month == current_date.month and day == current_date.day:
+        return True
+
+    # 29.02 в невисокосный год → отмечаем 28.02
+    is_leap = (current_date.year % 4 == 0 and current_date.year % 100 != 0) or current_date.year % 400 == 0
+    if month == 2 and day == 29 and not is_leap and current_date.month == 2 and current_date.day == 28:
+        return True
+
+    return False
+
+
 def build_selection_pool(
     db_session,
     game_id: int,
     players: List[TGUser],
-    current_date: date
-) -> Tuple[List[TGUser], Set[int]]:
+    current_date: date,
+    birthday_multiplier: int = 1,
+) -> Tuple[List[TGUser], Set[int], Set[int]]:
     """
-    Создать пул выбора с учётом двойного шанса.
+    Создать пул выбора с учётом двойного шанса и бонуса именинника.
 
     Игроки с активным двойным шансом добавляются в пул экспоненциально:
     1 покупка = 2^1 = 2 записи, 2 покупки = 2^2 = 4 записи, и т.д.
+
+    Если у игрока сегодня день рождения, его количество записей домножается
+    на `birthday_multiplier`. При `birthday_multiplier == 1` фича отключена.
     """
     from bot.app.models import DoubleChancePurchase
 
     selection_pool = []
     players_with_double_chance = set()
+    players_with_birthday = set()
 
     current_year = current_date.year
     current_day = current_date.timetuple().tm_yday
@@ -80,20 +107,31 @@ def build_selection_pool(
 
     for player in players:
         purchase_count = purchase_counts.get(player.id, 0)
+        has_birthday = birthday_multiplier > 1 and is_player_birthday(player, current_date)
 
-        if purchase_count > 0:
-            # Экспоненциальная логика: 2^n записей
-            entries_count = 2 ** purchase_count
-            for _ in range(entries_count):
-                selection_pool.append(player)
-            players_with_double_chance.add(player.id)
-            logger.debug(f"Player {player.id} ({player.full_username()}) has {purchase_count} double chance purchase(s), added {entries_count} times")
-        else:
-            # Добавляем игрока один раз
+        entries_count = (2 ** purchase_count) if purchase_count > 0 else 1
+        if has_birthday:
+            entries_count *= birthday_multiplier
+            players_with_birthday.add(player.id)
+
+        for _ in range(entries_count):
             selection_pool.append(player)
 
-    logger.info(f"Built selection pool: {len(selection_pool)} entries, {len(players_with_double_chance)} players with double chance")
-    return selection_pool, players_with_double_chance
+        if purchase_count > 0:
+            players_with_double_chance.add(player.id)
+
+        if entries_count > 1:
+            logger.debug(
+                f"Player {player.id} ({player.full_username()}) entries={entries_count} "
+                f"(double_chance={purchase_count}, birthday={has_birthday})"
+            )
+
+    logger.info(
+        f"Built selection pool: {len(selection_pool)} entries, "
+        f"{len(players_with_double_chance)} with double chance, "
+        f"{len(players_with_birthday)} with birthday"
+    )
+    return selection_pool, players_with_double_chance, players_with_birthday
 
 
 def check_winner_immunity(

--- a/bot/handlers/game/game_effects_service.py
+++ b/bot/handlers/game/game_effects_service.py
@@ -1,4 +1,5 @@
 """Service functions for game effects (immunity, double chance)."""
+import calendar
 import logging
 from collections import Counter
 from datetime import date, datetime
@@ -52,8 +53,8 @@ def is_player_birthday(player: TGUser, current_date: date) -> bool:
     29 февраля в невисокосный год считаем за 28.02 — иначе человек никогда
     не получит бонус.
     """
-    month = getattr(player, 'birth_month', None)
-    day = getattr(player, 'birth_day', None)
+    month = player.birth_month
+    day = player.birth_day
     if month is None or day is None:
         return False
 
@@ -61,8 +62,9 @@ def is_player_birthday(player: TGUser, current_date: date) -> bool:
         return True
 
     # 29.02 в невисокосный год → отмечаем 28.02
-    is_leap = (current_date.year % 4 == 0 and current_date.year % 100 != 0) or current_date.year % 400 == 0
-    if month == 2 and day == 29 and not is_leap and current_date.month == 2 and current_date.day == 28:
+    if (month == 2 and day == 29
+            and current_date.month == 2 and current_date.day == 28
+            and not calendar.isleap(current_date.year)):
         return True
 
     return False

--- a/bot/handlers/game/selection_service.py
+++ b/bot/handlers/game/selection_service.py
@@ -25,6 +25,12 @@ class SelectionResult:
     all_protected: bool  # Были ли все игроки защищены
     protected_player: Optional[TGUser] = None  # Игрок, который был защищён (если была защита)
     immunity_buyer_id: Optional[int] = None  # Кто купил защиту сработавшему игроку
+    had_birthday_bonus: bool = False  # Был ли у победителя бонус именинника
+    birthday_players: List[TGUser] = None  # Все именинники среди игроков (для анонса)
+
+    def __post_init__(self):
+        if self.birthday_players is None:
+            self.birthday_players = []
 
 
 def build_selection_context(
@@ -32,8 +38,9 @@ def build_selection_context(
     game_id: int,
     players: List[TGUser],
     current_date: date,
-    immunity_enabled: bool = True
-) -> tuple[List[TGUser], List[TGUser], List[TGUser], Set[int]]:
+    immunity_enabled: bool = True,
+    birthday_multiplier: int = 1,
+) -> tuple[List[TGUser], List[TGUser], List[TGUser], Set[int], Set[int]]:
     """
     Подготовить контекст для выбора победителя.
 
@@ -43,13 +50,15 @@ def build_selection_context(
         players: Список всех игроков
         current_date: Текущая дата
         immunity_enabled: Включена ли защита (по умолчанию True)
+        birthday_multiplier: Множитель для именинника (1 = фича отключена)
 
     Returns:
         Кортеж из:
-        - selection_pool: Пул для выбора (с учётом двойного шанса)
+        - selection_pool: Пул для выбора (с учётом двойного шанса и ДР)
         - unprotected_players: Незащищённые игроки
         - protected_players: Защищённые игроки
         - players_with_double_chance: Множество ID игроков с двойным шансом
+        - players_with_birthday: Множество ID именинников
     """
     # Если защита включена, фильтруем защищённых игроков
     if immunity_enabled:
@@ -61,19 +70,26 @@ def build_selection_context(
         unprotected_players = players
         protected_players = []
 
-    # Создаём пул выбора с учётом двойного шанса
-    selection_pool, players_with_double_chance = build_selection_pool(
-        db_session, game_id, players, current_date
+    # Создаём пул выбора с учётом двойного шанса и бонуса именинника
+    selection_pool, players_with_double_chance, players_with_birthday = build_selection_pool(
+        db_session, game_id, players, current_date, birthday_multiplier=birthday_multiplier
     )
 
     logger.debug(
         f"Selection context: {len(selection_pool)} in pool, "
         f"{len(unprotected_players)} unprotected, "
         f"{len(protected_players)} protected, "
-        f"{len(players_with_double_chance)} with double chance"
+        f"{len(players_with_double_chance)} with double chance, "
+        f"{len(players_with_birthday)} with birthday"
     )
 
-    return selection_pool, unprotected_players, protected_players, players_with_double_chance
+    return (
+        selection_pool,
+        unprotected_players,
+        protected_players,
+        players_with_double_chance,
+        players_with_birthday,
+    )
 
 
 def select_winner_with_effects(
@@ -81,10 +97,11 @@ def select_winner_with_effects(
     game_id: int,
     players: List[TGUser],
     current_date: date,
-    immunity_enabled: bool = True
+    immunity_enabled: bool = True,
+    birthday_multiplier: int = 1,
 ) -> Optional[SelectionResult]:
     """
-    Выбрать победителя с учётом защиты и двойного шанса.
+    Выбрать победителя с учётом защиты, двойного шанса и бонуса именинника.
 
     Args:
         db_session: Сессия БД
@@ -92,13 +109,23 @@ def select_winner_with_effects(
         players: Список всех игроков
         current_date: Текущая дата
         immunity_enabled: Включена ли защита (по умолчанию True)
+        birthday_multiplier: Множитель шанса для именинника (1 = фича отключена)
 
     Returns:
         SelectionResult с информацией о выборе или None если все защищены
     """
     # Подготавливаем контекст для выбора
-    selection_pool, unprotected_players, protected_players, players_with_double_chance = \
-        build_selection_context(db_session, game_id, players, current_date, immunity_enabled)
+    (
+        selection_pool,
+        unprotected_players,
+        protected_players,
+        players_with_double_chance,
+        players_with_birthday,
+    ) = build_selection_context(
+        db_session, game_id, players, current_date, immunity_enabled, birthday_multiplier
+    )
+
+    birthday_players = [p for p in players if p.id in players_with_birthday]
 
     # Если все игроки защищены - возвращаем None
     if immunity_enabled and len(unprotected_players) == 0:
@@ -107,15 +134,17 @@ def select_winner_with_effects(
             winner=None,
             had_immunity=False,
             had_double_chance=False,
-            all_protected=True
+            all_protected=True,
+            birthday_players=birthday_players,
         )
 
     # Выбираем победителя из пула
     winner = random.choice(selection_pool)
     logger.info(f"Winner selected: {winner.full_username()}")
 
-    # Запоминаем, был ли у победителя двойной шанс
+    # Запоминаем эффекты, сработавшие на победителя
     winner_had_double_chance = winner.id in players_with_double_chance
+    winner_had_birthday = winner.id in players_with_birthday
 
     # Проверяем защиту победителя только если она включена
     had_immunity = False
@@ -133,8 +162,9 @@ def select_winner_with_effects(
             winner = random.choice(unprotected_players)
             logger.info(f"Reselected winner after immunity: {winner.full_username()}")
 
-            # Обновляем информацию о двойном шансе для нового победителя
+            # Обновляем информацию об эффектах для нового победителя
             winner_had_double_chance = winner.id in players_with_double_chance
+            winner_had_birthday = winner.id in players_with_birthday
 
     return SelectionResult(
         winner=winner,
@@ -142,5 +172,7 @@ def select_winner_with_effects(
         had_double_chance=winner_had_double_chance,
         all_protected=False,
         protected_player=protected_player,
-        immunity_buyer_id=immunity_buyer_id
+        immunity_buyer_id=immunity_buyer_id,
+        had_birthday_bonus=winner_had_birthday,
+        birthday_players=birthday_players,
     )

--- a/bot/handlers/game/selection_service.py
+++ b/bot/handlers/game/selection_service.py
@@ -1,7 +1,7 @@
 """Service for selecting winners with game effects (immunity, double chance)."""
 import logging
 import random
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date
 from typing import List, Set, Optional
 
@@ -26,11 +26,7 @@ class SelectionResult:
     protected_player: Optional[TGUser] = None  # Игрок, который был защищён (если была защита)
     immunity_buyer_id: Optional[int] = None  # Кто купил защиту сработавшему игроку
     had_birthday_bonus: bool = False  # Был ли у победителя бонус именинника
-    birthday_players: List[TGUser] = None  # Все именинники среди игроков (для анонса)
-
-    def __post_init__(self):
-        if self.birthday_players is None:
-            self.birthday_players = []
+    birthday_players: List[TGUser] = field(default_factory=list)  # Все именинники среди игроков
 
 
 def build_selection_context(

--- a/bot/handlers/game/text_static.py
+++ b/bot/handlers/game/text_static.py
@@ -616,6 +616,7 @@ def get_rules_message(config) -> str:
 📊 *Команды:*
 • /pidor \\- запустить розыгрыш
 • /pidoreg \\- регистрация
+• /pidorbirthday \\- задать день рождения \\(в этот день x4 шанс\\)
 • /pidorstats \\- статистика
 • /pidorcoins \\- баланс койнов
 • /pidorshop \\- магазин
@@ -623,3 +624,21 @@ def get_rules_message(config) -> str:
 • /pidorrules \\- эти правила
 
 _Удачи в игре\\! Или не удачи\\.\\.\\. 🎲_"""
+
+
+# Бонус именинника
+BIRTHDAY_SET = "🎂 Запомнил твой день рождения: {date}. В этот день шанс стать пидором будет x{mult}!"
+BIRTHDAY_CLEARED = "Очистил твой день рождения."
+BIRTHDAY_USAGE = (
+    "Используй формат: /pidorbirthday DD.MM (например, /pidorbirthday 15.03).\n"
+    "Чтобы стереть — /pidorbirthday clear."
+)
+BIRTHDAY_INVALID = "Не понял дату. " + BIRTHDAY_USAGE
+BIRTHDAY_INFO_SET = "У тебя установлен день рождения: {date}."
+BIRTHDAY_INFO_NONE = "День рождения не установлен. " + BIRTHDAY_USAGE
+BIRTHDAY_DISABLED = "Бонус именинника в этом чате выключен."
+
+# Анонсы в /pidor (HTML)
+BIRTHDAY_ANNOUNCEMENT_SINGLE = "🎂 Сегодня день рождения у <b>{names}</b> — шанс стать пидором x{mult}!"
+BIRTHDAY_ANNOUNCEMENT_MULTIPLE = "🎂 Сегодня дни рождения сразу у нескольких игроков: <b>{names}</b> — у каждого шанс стать пидором x{mult}!"
+BIRTHDAY_WIN_SUFFIX = "\n\n🎉 И в свой день рождения пидором становится <b>{username}</b>!"

--- a/bot/setup_commands.py
+++ b/bot/setup_commands.py
@@ -16,6 +16,7 @@ commands = [
     ('pidor', 'play the game, see /pidorules first'),
     ('pidorules', 'POTD game rules'),
     ('pidoreg', 'register to the POTD game'),
+    ('pidorbirthday', 'set your birthday (DD.MM) for x4 chance on that day'),
     # ('pidoregmany', 'register many users to the POTD game'),
     # ('pidorunreg', 'unregister from the POTD game'),
     ('pidorstats', 'POTD game stats for this year'),

--- a/migrations/versions/p1q2r3s4t5u6_add_birthday_to_tguser.py
+++ b/migrations/versions/p1q2r3s4t5u6_add_birthday_to_tguser.py
@@ -1,0 +1,36 @@
+"""add_birthday_to_tguser
+
+Revision ID: p1q2r3s4t5u6
+Revises: o0p1q2r3s4t5
+Create Date: 2026-05-12 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'p1q2r3s4t5u6'
+down_revision = 'o0p1q2r3s4t5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    columns = [col['name'] for col in inspector.get_columns('tguser')]
+
+    if 'birth_month' not in columns:
+        op.add_column('tguser', sa.Column('birth_month', sa.Integer(), nullable=True))
+    if 'birth_day' not in columns:
+        op.add_column('tguser', sa.Column('birth_day', sa.Integer(), nullable=True))
+
+    # Бэкфилл ДР производится отдельным шагом — scripts/apply_birthdays.py
+    # читает приватный birthdays.local.json и проставляет UPDATE.
+    # Сделано так, чтобы tg_id живых людей не попадали в git.
+
+
+def downgrade() -> None:
+    op.drop_column('tguser', 'birth_day')
+    op.drop_column('tguser', 'birth_month')

--- a/scripts/apply_birthdays.py
+++ b/scripts/apply_birthdays.py
@@ -1,0 +1,112 @@
+"""
+Применяет дни рождения к БД из локального JSON-файла.
+
+Файл `scripts/birthdays.local.json` лежит в .gitignore, чтобы tg_id и ДР
+реальных людей не утекали в публичный репозиторий. Сначала миграция
+`p1q2r3s4t5u6_add_birthday_to_tguser.py` добавляет колонки, потом этот
+скрипт заливает данные. Идемпотентный — можно гонять сколько угодно раз.
+
+Формат `birthdays.local.json`:
+    {
+        "105825137": {"month": 6, "day": 17, "name": "kanst9"},
+        "5627861754": {"month": null, "day": null, "name": "divnitydat"},
+        ...
+    }
+
+Записи с null для month или day игнорируются — это плейсхолдеры под
+заполнение в будущем.
+
+Запуск:
+    DATABASE_URL=... python scripts/apply_birthdays.py [--file path] [--dry-run]
+"""
+import argparse
+import json
+import os
+import sys
+from typing import Dict
+
+from sqlmodel import Session, create_engine, text
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+DEFAULT_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'birthdays.local.json')
+
+
+def load_file(path: str) -> Dict[int, tuple[int, int]]:
+    if not os.path.exists(path):
+        print(f'Файл не найден: {path}', file=sys.stderr)
+        sys.exit(1)
+
+    with open(path, 'r', encoding='utf-8') as f:
+        raw = json.load(f)
+
+    result: Dict[int, tuple[int, int]] = {}
+    for tg_id_str, entry in raw.items():
+        try:
+            tg_id = int(tg_id_str)
+        except ValueError:
+            print(f'  Пропускаю некорректный tg_id: {tg_id_str!r}', file=sys.stderr)
+            continue
+        month = entry.get('month')
+        day = entry.get('day')
+        if month is None or day is None:
+            continue  # плейсхолдер
+        result[tg_id] = (int(month), int(day))
+    return result
+
+
+def apply(birthdays: Dict[int, tuple[int, int]], dry_run: bool) -> None:
+    db_url = os.environ['DATABASE_URL']
+    engine = create_engine(db_url)
+    updated = 0
+    not_found = []
+    with Session(engine) as session:
+        for tg_id, (month, day) in birthdays.items():
+            stmt = text(
+                'UPDATE tguser SET birth_month = :m, birth_day = :d '
+                'WHERE tg_id = :tg_id'
+            )
+            if dry_run:
+                # Проверяем существование без записи
+                check = session.exec(
+                    text('SELECT id FROM tguser WHERE tg_id = :tg_id'),
+                    params={'tg_id': tg_id},
+                ).first()
+                if check is None:
+                    not_found.append(tg_id)
+                else:
+                    print(f'  [dry-run] UPDATE tg_id={tg_id} → {day:02d}.{month:02d}')
+                    updated += 1
+            else:
+                result = session.exec(stmt, params={'m': month, 'd': day, 'tg_id': tg_id})
+                if result.rowcount == 0:
+                    not_found.append(tg_id)
+                else:
+                    updated += 1
+        if not dry_run:
+            session.commit()
+
+    print(f'\n{"[dry-run] " if dry_run else ""}Обновлено: {updated}')
+    if not_found:
+        print(f'Не найдены в БД ({len(not_found)}): {not_found}')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--file', default=DEFAULT_FILE,
+                        help=f'Путь к JSON с ДР (по умолчанию: {DEFAULT_FILE})')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Показать что будет сделано, но не писать в БД.')
+    args = parser.parse_args()
+
+    birthdays = load_file(args.file)
+    if not birthdays:
+        print('В файле нет заполненных ДР (только плейсхолдеры или пусто).', file=sys.stderr)
+        sys.exit(0)
+
+    print(f'Применяю {len(birthdays)} ДР из {args.file}...', file=sys.stderr)
+    apply(birthdays, dry_run=args.dry_run)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/extract_birthdays.py
+++ b/scripts/extract_birthdays.py
@@ -1,0 +1,189 @@
+"""
+Извлекает дни рождения зарегистрированных игроков из Telegram через MTProto.
+
+Запуск:
+    TELEGRAM_API_ID=... TELEGRAM_API_HASH=... DATABASE_URL=... \\
+        python scripts/extract_birthdays.py [--game-id N] [--tg-ids 1,2,3]
+
+ТРЕБОВАНИЯ:
+  • Telethon >= 1.36 (поле `birthday` появилось в Layer 181).
+    Проверить: `python -c "import telethon; print(telethon.__version__)"`
+    Обновить: `pip install -U "telethon>=1.36"`
+
+При первом запуске Telethon попросит код подтверждения и сохранит сессию
+в `birthday_extract.session`. Скрипт сразу прогревает кэш через get_dialogs(),
+чтобы Telegram отдал access_hash для игроков, которых ты «знаешь»
+(переписки/общие чаты/контакты).
+
+Логика резолва entity:
+  1. Кэш Telethon после get_dialogs()
+  2. Если есть username — fallback через client.get_entity('username')
+  3. Если оба не сработали — записывается в missing
+
+Вывод: готовый кусок для вставки в миграцию, например:
+    BIRTHDAYS = {
+        12345: (3, 15),
+        67890: (11, 7),
+    }
+    # Missing: [11111, 22222]
+
+ВНИМАНИЕ: поле birthday в Telegram доступно только если игрок:
+  1) указал его в профиле, и
+  2) разрешил видеть либо всем, либо контактам (включая тебя).
+"""
+import argparse
+import asyncio
+import os
+import sys
+from typing import Dict, List, Optional, Tuple
+
+from sqlmodel import Session, create_engine, select
+from telethon import TelegramClient
+from telethon.tl.functions.users import GetFullUserRequest
+
+# Чтобы скрипт работал из корня проекта без установки пакета
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from bot.app.models import GamePlayer, TGUser  # noqa: E402
+
+
+SESSION_NAME = 'birthday_extract'
+
+
+class Target:
+    __slots__ = ('tg_id', 'username', 'display')
+
+    def __init__(self, tg_id: int, username: Optional[str], display: str):
+        self.tg_id = tg_id
+        self.username = username
+        self.display = display
+
+
+def load_targets_from_db(game_id: Optional[int]) -> List[Target]:
+    db_url = os.environ['DATABASE_URL']
+    engine = create_engine(db_url)
+    with Session(engine) as session:
+        if game_id is not None:
+            stmt = (
+                select(TGUser)
+                .join(GamePlayer, GamePlayer.user_id == TGUser.id)
+                .where(GamePlayer.game_id == game_id, GamePlayer.is_active == True)  # noqa: E712
+            )
+        else:
+            stmt = select(TGUser)
+        users = session.exec(stmt).all()
+        return [Target(u.tg_id, u.username, u.full_username()) for u in users]
+
+
+def _check_telethon_version() -> None:
+    try:
+        import telethon
+        ver = tuple(int(x) for x in telethon.__version__.split('.')[:2])
+        if ver < (1, 36):
+            print(
+                f'⚠️  Telethon {telethon.__version__} слишком старый.\n'
+                f'   Поле `birthday` появилось в 1.36+. Обнови: pip install -U "telethon>=1.36"',
+                file=sys.stderr,
+            )
+            sys.exit(2)
+    except Exception:
+        pass  # на всякий случай не блокируем
+
+
+async def _resolve_entity(client: TelegramClient, t: Target):
+    """Пытается резолвить пользователя: сначала по id (после dialogs), потом по username."""
+    # 1) Прямой резолв из локального кэша Telethon
+    try:
+        return await client.get_input_entity(t.tg_id)
+    except (ValueError, Exception):
+        pass
+
+    # 2) Fallback через username (работает для публичных аккаунтов)
+    if t.username:
+        try:
+            return await client.get_entity(t.username)
+        except Exception:
+            pass
+
+    return None
+
+
+async def fetch_birthdays(targets: List[Target]) -> Tuple[Dict[int, Tuple[int, int]], List[Tuple[int, str, str]]]:
+    api_id = int(os.environ['TELEGRAM_API_ID'])
+    api_hash = os.environ['TELEGRAM_API_HASH']
+
+    found: Dict[int, Tuple[int, int]] = {}
+    missing: List[Tuple[int, str, str]] = []  # (tg_id, display, reason)
+
+    async with TelegramClient(SESSION_NAME, api_id, api_hash) as client:
+        # Прогреваем кэш — подтягиваем диалоги, чтобы Telegram отдал access_hash
+        print('Прогреваю кэш диалогов (get_dialogs)...', file=sys.stderr)
+        dialog_count = 0
+        async for _ in client.iter_dialogs():
+            dialog_count += 1
+        print(f'  Загружено {dialog_count} диалогов', file=sys.stderr)
+
+        for t in targets:
+            try:
+                entity = await _resolve_entity(client, t)
+                if entity is None:
+                    missing.append((t.tg_id, t.display, 'entity not resolved (no dialog, no public username)'))
+                    continue
+
+                full = await client(GetFullUserRequest(entity))
+                # В Telethon <1.36 поля birthday не существует
+                birthday = getattr(full.full_user, 'birthday', None)
+                if birthday is None:
+                    missing.append((t.tg_id, t.display, 'birthday not set / hidden'))
+                else:
+                    found[t.tg_id] = (birthday.month, birthday.day)
+                    print(f'  ✓ {t.display} ({t.tg_id}): {birthday.day:02d}.{birthday.month:02d}', file=sys.stderr)
+            except Exception as e:
+                missing.append((t.tg_id, t.display, type(e).__name__ + ': ' + str(e)))
+            # Бережём API от флуд-лимитов
+            await asyncio.sleep(0.3)
+
+    return found, missing
+
+
+def print_migration_block(found: Dict[int, Tuple[int, int]], missing: List[Tuple[int, str, str]]) -> None:
+    print()
+    print('# === Вставь в миграцию ===')
+    print('BIRTHDAYS = {')
+    for tg_id, (m, d) in sorted(found.items()):
+        print(f'    {tg_id}: ({m}, {d}),')
+    print('}')
+    print()
+    if missing:
+        print(f'# Missing ({len(missing)}) — добей вручную:')
+        for tg_id, display, reason in missing:
+            print(f'#   {tg_id} ({display}): {reason}')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--game-id', type=int, default=None,
+                        help='Брать активных игроков только этой игры. По умолчанию — все TGUser.')
+    parser.add_argument('--tg-ids', type=str, default=None,
+                        help='Список tg_id через запятую (перебивает --game-id и БД).')
+    args = parser.parse_args()
+
+    _check_telethon_version()
+
+    if args.tg_ids:
+        targets = [Target(int(x.strip()), None, f'<id={x.strip()}>')
+                   for x in args.tg_ids.split(',') if x.strip()]
+    else:
+        targets = load_targets_from_db(args.game_id)
+
+    if not targets:
+        print('Нет tg_id для проверки.', file=sys.stderr)
+        sys.exit(1)
+
+    print(f'Проверяю {len(targets)} пользователей...', file=sys.stderr)
+    found, missing = asyncio.run(fetch_birthdays(targets))
+    print_migration_block(found, missing)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/extract_birthdays.py
+++ b/scripts/extract_birthdays.py
@@ -95,7 +95,7 @@ async def _resolve_entity(client: TelegramClient, t: Target):
     # 1) Прямой резолв из локального кэша Telethon
     try:
         return await client.get_input_entity(t.tg_id)
-    except (ValueError, Exception):
+    except Exception:
         pass
 
     # 2) Fallback через username (работает для публичных аккаунтов)

--- a/tests/handlers/game/test_birthday.py
+++ b/tests/handlers/game/test_birthday.py
@@ -1,14 +1,15 @@
 """Тесты бонуса именинника."""
 from datetime import date
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from bot.app.models import TGUser
-from bot.handlers.game.commands import _parse_birthday
+from bot.handlers.game.commands import _parse_birthday, pidorbirthday_cmd
 from bot.handlers.game.game_effects_service import (
     build_selection_pool, is_player_birthday
 )
+from bot.handlers.game.selection_service import select_winner_with_effects
 
 
 def _player(uid: int, month=None, day=None) -> TGUser:
@@ -179,3 +180,191 @@ def test_parse_birthday_valid(text, expected):
 ])
 def test_parse_birthday_invalid(text):
     assert _parse_birthday(text) is None
+
+
+# ─── pidorbirthday_cmd (integration) ─────────────────────────────────
+
+@pytest.fixture
+def _bday_update():
+    """Mock update с настроенным effective_message.reply_text."""
+    update = MagicMock()
+    update.effective_chat = MagicMock()
+    update.effective_chat.id = 987654321
+    update.effective_message = MagicMock()
+    update.effective_message.reply_text = AsyncMock()
+    update.message = MagicMock()
+    update.message.text = "/pidorbirthday"
+    return update
+
+
+@pytest.fixture
+def _bday_context():
+    """Mock context с tg_user и моком db_session."""
+    ctx = MagicMock()
+    ctx.db_session = MagicMock()
+    ctx.db_session.add = MagicMock()
+    ctx.db_session.commit = MagicMock()
+    user = TGUser(id=1, tg_id=100, first_name='Test', username='testuser',
+                  birth_month=None, birth_day=None)
+    ctx.tg_user = user
+    return ctx
+
+
+def _mock_config(mocker, enabled=True, multiplier=4):
+    """Подменяет get_config для команды."""
+    cfg = MagicMock()
+    cfg.constants.birthday_enabled = enabled
+    cfg.constants.birthday_bonus_multiplier = multiplier
+    mocker.patch('bot.handlers.game.commands.get_config', return_value=cfg)
+    return cfg
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_birthday_cmd_set_valid(_bday_update, _bday_context, mocker):
+    _mock_config(mocker)
+    _bday_update.message.text = "/pidorbirthday 15.03"
+
+    await pidorbirthday_cmd(_bday_update, _bday_context)
+
+    assert _bday_context.tg_user.birth_month == 3
+    assert _bday_context.tg_user.birth_day == 15
+    _bday_context.db_session.commit.assert_called_once()
+    reply = _bday_update.effective_message.reply_text.await_args[0][0]
+    assert '15.03' in reply
+    assert 'x4' in reply
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_birthday_cmd_clear(_bday_update, _bday_context, mocker):
+    _mock_config(mocker)
+    _bday_context.tg_user.birth_month = 3
+    _bday_context.tg_user.birth_day = 15
+    _bday_update.message.text = "/pidorbirthday clear"
+
+    await pidorbirthday_cmd(_bday_update, _bday_context)
+
+    assert _bday_context.tg_user.birth_month is None
+    assert _bday_context.tg_user.birth_day is None
+    _bday_context.db_session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_birthday_cmd_invalid_date(_bday_update, _bday_context, mocker):
+    _mock_config(mocker)
+    _bday_update.message.text = "/pidorbirthday 31.02"  # такого дня нет
+
+    await pidorbirthday_cmd(_bday_update, _bday_context)
+
+    # Юзер не обновился, commit не вызван
+    assert _bday_context.tg_user.birth_month is None
+    assert _bday_context.tg_user.birth_day is None
+    _bday_context.db_session.commit.assert_not_called()
+    reply = _bday_update.effective_message.reply_text.await_args[0][0]
+    assert 'не понял' in reply.lower() or 'формат' in reply.lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_birthday_cmd_info_when_unset(_bday_update, _bday_context, mocker):
+    _mock_config(mocker)
+    _bday_update.message.text = "/pidorbirthday"
+
+    await pidorbirthday_cmd(_bday_update, _bday_context)
+
+    _bday_context.db_session.commit.assert_not_called()
+    reply = _bday_update.effective_message.reply_text.await_args[0][0]
+    assert 'не установлен' in reply.lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_birthday_cmd_info_when_set(_bday_update, _bday_context, mocker):
+    _mock_config(mocker)
+    _bday_context.tg_user.birth_month = 7
+    _bday_context.tg_user.birth_day = 4
+    _bday_update.message.text = "/pidorbirthday"
+
+    await pidorbirthday_cmd(_bday_update, _bday_context)
+
+    _bday_context.db_session.commit.assert_not_called()
+    reply = _bday_update.effective_message.reply_text.await_args[0][0]
+    assert '04.07' in reply
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_birthday_cmd_disabled_via_config(_bday_update, _bday_context, mocker):
+    _mock_config(mocker, enabled=False)
+    _bday_update.message.text = "/pidorbirthday 15.03"
+
+    await pidorbirthday_cmd(_bday_update, _bday_context)
+
+    # Фича отключена — никаких изменений
+    assert _bday_context.tg_user.birth_month is None
+    _bday_context.db_session.commit.assert_not_called()
+    reply = _bday_update.effective_message.reply_text.await_args[0][0]
+    assert 'выключен' in reply.lower() or 'отключ' in reply.lower()
+
+
+# ─── Множественные именинники + immunity-reroll ───────────────────────
+
+@pytest.mark.unit
+def test_pool_multiple_birthday_players(mock_db_session):
+    """Несколько именинников в один день — все получают бонус."""
+    _mock_no_double_chance(mock_db_session)
+    bd1 = _player(1, month=5, day=13)
+    bd2 = _player(2, month=5, day=13)
+    other = _player(3)
+
+    pool, _dc, bd = build_selection_pool(
+        mock_db_session, 1, [bd1, bd2, other],
+        date(2026, 5, 13), birthday_multiplier=4,
+    )
+
+    assert pool.count(bd1) == 4
+    assert pool.count(bd2) == 4
+    assert pool.count(other) == 1
+    assert {bd1.id, bd2.id} == bd
+    assert other.id not in bd
+
+
+@pytest.mark.unit
+def test_select_winner_immunity_reroll_drops_birthday_bonus(mock_db_session, mocker):
+    """Когда именинник защищён и происходит reroll на обычного игрока,
+    had_birthday_bonus у итогового победителя должен быть False."""
+    # Patch filter_protected_players: именинник защищён
+    birthday_player = _player(1, month=5, day=13)
+    regular = _player(2)
+
+    mocker.patch(
+        'bot.handlers.game.selection_service.filter_protected_players',
+        return_value=([regular], [birthday_player]),
+    )
+    # build_selection_pool делаем стабильным — defer to real function
+    _mock_no_double_chance(mock_db_session)
+    # random.choice пусть всегда выбирает первого из пула, чтобы попасть на именинника
+    mocker.patch(
+        'bot.handlers.game.selection_service.random.choice',
+        side_effect=lambda lst: lst[0],
+    )
+    # И защита у именинника срабатывает
+    mocker.patch(
+        'bot.handlers.game.selection_service.check_winner_immunity',
+        return_value=999,  # buyer_id
+    )
+
+    result = select_winner_with_effects(
+        mock_db_session, game_id=1, players=[birthday_player, regular],
+        current_date=date(2026, 5, 13), immunity_enabled=True,
+        birthday_multiplier=4,
+    )
+
+    # Итоговый победитель — regular (reroll), у него нет ДР
+    assert result.winner.id == regular.id
+    assert result.had_immunity is True
+    assert result.had_birthday_bonus is False
+    # Но в birthday_players именинник всё равно отмечен (для анонса)
+    assert birthday_player in result.birthday_players

--- a/tests/handlers/game/test_birthday.py
+++ b/tests/handlers/game/test_birthday.py
@@ -1,0 +1,181 @@
+"""Тесты бонуса именинника."""
+from datetime import date
+from unittest.mock import MagicMock
+
+import pytest
+
+from bot.app.models import TGUser
+from bot.handlers.game.commands import _parse_birthday
+from bot.handlers.game.game_effects_service import (
+    build_selection_pool, is_player_birthday
+)
+
+
+def _player(uid: int, month=None, day=None) -> TGUser:
+    return TGUser(
+        id=uid, tg_id=100 + uid, first_name=f"P{uid}", username=f"p{uid}",
+        birth_month=month, birth_day=day,
+    )
+
+
+def _mock_no_double_chance(mock_db_session):
+    """Заглушка: нет активных покупок double_chance."""
+    result = MagicMock()
+    result.all.return_value = []
+    mock_db_session.exec.return_value = result
+
+
+# ─── is_player_birthday ──────────────────────────────────────────────
+
+@pytest.mark.unit
+def test_is_player_birthday_matches():
+    p = _player(1, month=5, day=13)
+    assert is_player_birthday(p, date(2026, 5, 13)) is True
+
+
+@pytest.mark.unit
+def test_is_player_birthday_different_day():
+    p = _player(1, month=5, day=13)
+    assert is_player_birthday(p, date(2026, 5, 14)) is False
+
+
+@pytest.mark.unit
+def test_is_player_birthday_no_data():
+    p = _player(1, month=None, day=None)
+    assert is_player_birthday(p, date(2026, 5, 13)) is False
+
+
+@pytest.mark.unit
+def test_is_player_birthday_feb_29_in_leap_year():
+    p = _player(1, month=2, day=29)
+    assert is_player_birthday(p, date(2024, 2, 29)) is True
+
+
+@pytest.mark.unit
+def test_is_player_birthday_feb_29_in_non_leap_year_celebrates_on_28():
+    p = _player(1, month=2, day=29)
+    # 2026 не високосный → отмечаем 28.02
+    assert is_player_birthday(p, date(2026, 2, 28)) is True
+    assert is_player_birthday(p, date(2026, 3, 1)) is False
+
+
+@pytest.mark.unit
+def test_is_player_birthday_feb_28_not_affected_by_feb_29_logic():
+    # Обычный игрок с ДР 28.02 не должен срабатывать дважды
+    p = _player(1, month=2, day=28)
+    assert is_player_birthday(p, date(2026, 2, 28)) is True
+    # Игрок с ДР 28.02 — на 28.02 совпадение по точному условию
+
+
+# ─── build_selection_pool: birthday bonus ────────────────────────────
+
+@pytest.mark.unit
+def test_pool_birthday_x4_multiplier(mock_db_session):
+    _mock_no_double_chance(mock_db_session)
+    birthday_player = _player(1, month=5, day=13)
+    other = _player(2)
+
+    pool, dc, bd = build_selection_pool(
+        mock_db_session, 1, [birthday_player, other],
+        date(2026, 5, 13), birthday_multiplier=4,
+    )
+
+    assert pool.count(birthday_player) == 4
+    assert pool.count(other) == 1
+    assert birthday_player.id in bd
+    assert other.id not in bd
+    assert birthday_player.id not in dc
+
+
+@pytest.mark.unit
+def test_pool_birthday_disabled_when_multiplier_is_1(mock_db_session):
+    _mock_no_double_chance(mock_db_session)
+    birthday_player = _player(1, month=5, day=13)
+    other = _player(2)
+
+    pool, _dc, bd = build_selection_pool(
+        mock_db_session, 1, [birthday_player, other],
+        date(2026, 5, 13), birthday_multiplier=1,
+    )
+
+    # multiplier=1 → фича отключена, никаких бонусов
+    assert pool.count(birthday_player) == 1
+    assert pool.count(other) == 1
+    assert len(bd) == 0
+
+
+@pytest.mark.unit
+def test_pool_birthday_combines_with_double_chance(mock_db_session):
+    """Именинник + 1 покупка double_chance: 2 * 4 = 8 записей."""
+    from bot.app.models import DoubleChancePurchase
+
+    birthday_player = _player(1, month=5, day=13)
+    other = _player(2)
+
+    purchase = DoubleChancePurchase(
+        game_id=1, buyer_id=99, target_id=birthday_player.id,
+        year=2026, day=date(2026, 5, 13).timetuple().tm_yday, is_used=False,
+    )
+    result = MagicMock()
+    result.all.return_value = [purchase]
+    mock_db_session.exec.return_value = result
+
+    pool, dc, bd = build_selection_pool(
+        mock_db_session, 1, [birthday_player, other],
+        date(2026, 5, 13), birthday_multiplier=4,
+    )
+
+    assert pool.count(birthday_player) == 8  # 2 ** 1 * 4
+    assert pool.count(other) == 1
+    assert birthday_player.id in dc
+    assert birthday_player.id in bd
+
+
+@pytest.mark.unit
+def test_pool_no_birthdays_today(mock_db_session):
+    _mock_no_double_chance(mock_db_session)
+    p1 = _player(1, month=12, day=31)
+    p2 = _player(2)
+
+    pool, _dc, bd = build_selection_pool(
+        mock_db_session, 1, [p1, p2],
+        date(2026, 5, 13), birthday_multiplier=4,
+    )
+
+    assert pool.count(p1) == 1
+    assert pool.count(p2) == 1
+    assert len(bd) == 0
+
+
+# ─── _parse_birthday ─────────────────────────────────────────────────
+
+@pytest.mark.unit
+@pytest.mark.parametrize("text,expected", [
+    ("15.03", (3, 15)),
+    ("05.12", (12, 5)),
+    ("1.1", (1, 1)),
+    ("29.02", (2, 29)),   # допускаем 29.02 — год учитывается в логике розыгрыша
+    ("31.12", (12, 31)),
+    ("15-03", (3, 15)),    # через дефис
+    ("15/03", (3, 15)),    # через слэш
+])
+def test_parse_birthday_valid(text, expected):
+    assert _parse_birthday(text) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("text", [
+    "",
+    "abc",
+    "15",
+    "15.03.2024",
+    "32.01",
+    "15.13",
+    "0.5",
+    "5.0",
+    "31.04",  # апрель — 30 дней
+    "31.02",
+    "-1.5",
+])
+def test_parse_birthday_invalid(text):
+    assert _parse_birthday(text) is None

--- a/tests/handlers/game/test_game_effects_service.py
+++ b/tests/handlers/game/test_game_effects_service.py
@@ -180,7 +180,7 @@ def test_build_selection_pool_with_double_chance(mock_db_session):
     mock_db_session.exec.return_value = mock_result
 
     # Execute
-    pool, double_chance_players = build_selection_pool(mock_db_session, game_id, players, current_date)
+    pool, double_chance_players, _birthday_players = build_selection_pool(mock_db_session, game_id, players, current_date)
 
     # Verify
     assert len(pool) == 3  # player1 twice + player2 once
@@ -229,7 +229,7 @@ def test_build_selection_pool_multiple_double_chance(mock_db_session):
     mock_db_session.exec.return_value = mock_result
 
     # Execute
-    pool, double_chance_players = build_selection_pool(mock_db_session, game_id, players, current_date)
+    pool, double_chance_players, _birthday_players = build_selection_pool(mock_db_session, game_id, players, current_date)
 
     # Verify - with exponential logic: 1 purchase = 2^1 = 2 entries
     assert len(pool) == 5  # player1 (2^1=2) + player2 (1) + player3 (2^1=2)
@@ -414,7 +414,7 @@ def test_build_selection_pool_exponential_double_chance(mock_db_session):
     mock_db_session.exec.return_value = mock_result
 
     # Execute
-    pool, double_chance_players = build_selection_pool(mock_db_session, game_id, players, current_date)
+    pool, double_chance_players, _birthday_players = build_selection_pool(mock_db_session, game_id, players, current_date)
 
     # Verify - with exponential logic: 2 purchases = 2^2 = 4 entries
     assert len(pool) == 5  # player1 (2^2=4) + player2 (1)
@@ -471,7 +471,7 @@ def test_build_selection_pool_triple_double_chance(mock_db_session):
     mock_db_session.exec.return_value = mock_result
 
     # Execute
-    pool, double_chance_players = build_selection_pool(mock_db_session, game_id, players, current_date)
+    pool, double_chance_players, _birthday_players = build_selection_pool(mock_db_session, game_id, players, current_date)
 
     # Verify - with exponential logic: 3 purchases = 2^3 = 8 entries
     assert len(pool) == 10  # player1 (2^3=8) + player2 (1) + player3 (1)

--- a/tests/handlers/game/test_selection_service.py
+++ b/tests/handlers/game/test_selection_service.py
@@ -359,7 +359,7 @@ def test_build_selection_context_normal(mock_db_session, sample_players):
 
     try:
         # Execute
-        selection_pool, unprotected, protected, double_chance_ids = build_selection_context(
+        selection_pool, unprotected, protected, double_chance_ids, _birthday_ids = build_selection_context(
             mock_db_session, game_id, players, current_date
         )
 
@@ -410,7 +410,7 @@ def test_build_selection_context_with_protection(mock_db_session, sample_players
 
     try:
         # Execute
-        selection_pool, unprotected, protected, double_chance_ids = build_selection_context(
+        selection_pool, unprotected, protected, double_chance_ids, _birthday_ids = build_selection_context(
             mock_db_session, game_id, players, current_date
         )
 
@@ -464,7 +464,7 @@ def test_build_selection_context_with_double_chance(mock_db_session, sample_play
 
     try:
         # Execute
-        selection_pool, unprotected, protected, double_chance_ids = build_selection_context(
+        selection_pool, unprotected, protected, double_chance_ids, _birthday_ids = build_selection_context(
             mock_db_session, game_id, players, current_date
         )
 
@@ -517,7 +517,7 @@ def test_build_selection_context_immunity_disabled(mock_db_session, sample_playe
 
     try:
         # Execute with immunity_enabled=False
-        selection_pool, unprotected, protected, double_chance_ids = build_selection_context(
+        selection_pool, unprotected, protected, double_chance_ids, _birthday_ids = build_selection_context(
             mock_db_session, game_id, players, current_date, immunity_enabled=False
         )
 
@@ -578,7 +578,7 @@ def test_build_selection_context_with_multiple_double_chance_same_player(mock_db
 
     try:
         # Execute
-        selection_pool, unprotected, protected, double_chance_ids = build_selection_context(
+        selection_pool, unprotected, protected, double_chance_ids, _birthday_ids = build_selection_context(
             mock_db_session, game_id, players, current_date
         )
 

--- a/vibe/pidorcoins-economy.md
+++ b/vibe/pidorcoins-economy.md
@@ -1346,6 +1346,62 @@ def select_winner_with_effects(
 
 ---
 
+### Обновление 2026-05-13 (v12): ✅ БОНУС ИМЕНИННИКА
+
+**В день рождения игрок попадает в пул выбора пидора x4 раза.**
+
+**Мотивация:**
+- Дать «плюшку» в ДР, не ломая годовой баланс. Койны на ДР всех бы уравняли, а множитель шанса добавляет драмы и сохраняет соревновательность.
+- Никакой ручной интеграции с Telegram Premium / API дней рождения не требуется — данные тянутся одним скриптом через MTProto.
+
+**Параметры:**
+
+| Параметр | Значение |
+|----------|----------|
+| Множитель | x4 в пуле выбора |
+| Где задаётся | `birthday_bonus_multiplier` в `GameConstants` |
+| Feature flag | `birthday_enabled` (по умолчанию: `True`) |
+| Хранение | `TGUser.birth_month` / `birth_day` (nullable) |
+| Источник данных | `/pidorbirthday DD.MM` или массовый бэкфилл через скрипт |
+| 29 февраля | В невисокосный год отмечаем 28.02 |
+
+**Механика:**
+- В `build_selection_pool` ID игрока попадает в пул `entries = (2 ** double_chance_count) * (multiplier if is_birthday else 1)` раз — мультипликативная композиция с покупным двойным шансом.
+- В `pidor_cmd` перед stage1 шлётся анонс с именинниками и множителем.
+- При победе именинника в stage4 добавляется отдельная плашка: «🎉 И в свой день рождения пидором становится {username}».
+- В `SelectionResult` появились `had_birthday_bonus: bool` и `birthday_players: List[TGUser]`.
+
+**Команды:**
+- `/pidorbirthday DD.MM` — установить
+- `/pidorbirthday clear` — стереть
+- `/pidorbirthday` без аргументов — показать текущее значение
+- Парсер принимает `15.03`, `15-03`, `15/03`
+
+**Бэкфилл (приватные данные не в репо):**
+- `scripts/extract_birthdays.py` (Telethon, MTProto): прогревает кэш через `iter_dialogs()`, резолвит игроков по `user_id` либо по `username`, тащит поле `birthday` из `users.getFullUser`. Требует Telethon >= 1.36.
+- Результат кладётся в `scripts/birthdays.local.json` (gitignored).
+- `scripts/apply_birthdays.py` — идемпотентный UPDATE из JSON в БД (с `--dry-run`).
+- Сама миграция `p1q2r3s4t5u6_add_birthday_to_tguser.py` содержит **только DDL** (две колонки) — реальные tg_id живых людей в git не попадают.
+
+**Новые и изменённые компоненты:**
+- `bot/app/models.py`: поля `birth_month`, `birth_day` в `TGUser`
+- `migrations/versions/p1q2r3s4t5u6_add_birthday_to_tguser.py`: новая миграция (только колонки)
+- `scripts/extract_birthdays.py`, `scripts/apply_birthdays.py`: помощники для бэкфилла
+- `bot/handlers/game/config.py`: `birthday_enabled = True`, `birthday_bonus_multiplier = 4`
+- `bot/handlers/game/game_effects_service.py`: `is_player_birthday()`, расширенный `build_selection_pool` (3 значения в кортеже вместо 2)
+- `bot/handlers/game/selection_service.py`: `SelectionResult.had_birthday_bonus`, `SelectionResult.birthday_players`; параметр `birthday_multiplier` в `select_winner_with_effects`
+- `bot/handlers/game/commands.py`: `pidorbirthday_cmd`, `_parse_birthday`, интеграция в `pidor_cmd`
+- `bot/handlers/game/text_static.py`: константы `BIRTHDAY_*`, упоминание `/pidorbirthday` в правилах
+- `bot/dispatcher.py`: регистрация `pidorbirthday_cmd`
+- `bot/setup_commands.py`: подсказка `/pidorbirthday` в Telegram BotFather
+
+**Тестовое покрытие:**
+- `tests/handlers/game/test_birthday.py` — 28 unit-тестов: проверка `is_player_birthday` (включая 29.02 в високосный/невисокосный год), пул с x4, комбинация x4 × double_chance = 8, валидация `_parse_birthday`
+- Обновлены вызовы `build_selection_pool` / `build_selection_context` в `test_selection_service.py`, `test_game_effects_service.py`
+- 568 тестов, все проходят ✅
+
+---
+
 ## 🐛 TODO: Известные баги и улучшения
 
 ### Баг: Достижения не выдаются при перевыборах


### PR DESCRIPTION
## Summary
- Бонус именинника: на свой ДР игрок попадает в пул выбора пидора x4 раза (по умолчанию). Мультипликативно складывается с double_chance.
- Хранение: `TGUser.birth_month` / `birth_day` (nullable). Команда `/pidorbirthday DD.MM` для установки, `/pidorbirthday clear` для сброса.
- Конфиг: фича-флаг `birthday_enabled` (по умолчанию `True`) и `birthday_bonus_multiplier` (по умолчанию `4`).
- Бэкфилл: миграция добавляет только колонки; реальные данные едут через гитигнор-файл `scripts/birthdays.local.json` + `scripts/apply_birthdays.py` (идемпотентный UPDATE). Это сделано, чтобы tg_id живых людей не попадали в git.
- `scripts/extract_birthdays.py` — Telethon-скрипт через MTProto, тянет ДР из профилей Telegram. Требует Telethon >= 1.36 (поле `birthday` в TL Layer 181).
- 29.02 в невисокосный год отмечаем 28.02.

## Test plan
- [x] 28 новых юнит-тестов в `tests/handlers/game/test_birthday.py`
- [x] Обновлены вызовы `build_selection_pool` / `build_selection_context` в существующих тестах
- [x] Полный suite: 568 passed
- [ ] Прокатать миграцию на проде (`alembic upgrade head`)
- [ ] Скопировать `birthdays.local.json` на под и применить (`python scripts/apply_birthdays.py --dry-run` → если ок, без `--dry-run`)
- [ ] Проверить `/pidorbirthday` в боевом чате
- [ ] Дождаться чьего-то ДР и убедиться, что анонс и плашка в результате срабатывают

🤖 Generated with [Claude Code](https://claude.com/claude-code)