### PR TITLE
feat: optional outbound HTTPS proxy for Telegram API

### DIFF
--- a/bot/setup_commands.py
+++ b/bot/setup_commands.py
@@ -3,6 +3,7 @@ import os
 
 from dotenv import load_dotenv
 from telegram import Bot
+from telegram.request import HTTPXRequest
 
 commands = [
     # ('slap', 'simulate /slap command from IRC'),
@@ -38,7 +39,9 @@ commands = [
 
 async def main():
     load_dotenv()
-    async with Bot(os.environ['TELEGRAM_BOT_API_SECRET']) as bot:
+    proxy = os.environ.get('BOT_HTTPS_PROXY')
+    request = HTTPXRequest(proxy=proxy, connect_timeout=20.0, read_timeout=30.0) if proxy else None
+    async with Bot(os.environ['TELEGRAM_BOT_API_SECRET'], request=request) as bot:
         await bot.delete_my_commands()
         # Setup similar commands for both 'en' and 'ru' users
         await bot.set_my_commands(commands)

--- a/deploy/charts/app/templates/db-init.yaml
+++ b/deploy/charts/app/templates/db-init.yaml
@@ -43,5 +43,11 @@ spec:
               secretKeyRef:
                 name: pidor-bot-secrets
                 key: tg_token
+          - name: BOT_HTTPS_PROXY
+            valueFrom:
+              secretKeyRef:
+                name: pidor-bot-secrets
+                key: bot_https_proxy
+                optional: true
       terminationGracePeriodSeconds: 30
       restartPolicy: OnFailure

--- a/deploy/charts/app/templates/deployment.yaml
+++ b/deploy/charts/app/templates/deployment.yaml
@@ -48,6 +48,12 @@ spec:
                 key: tg_token
           - name: GAME_CONFIG_PATH
             value: "/config/game-config.json"
+          - name: BOT_HTTPS_PROXY
+            valueFrom:
+              secretKeyRef:
+                name: pidor-bot-secrets
+                key: bot_https_proxy
+                optional: true
           volumeMounts:
           - name: game-config
             mountPath: /config

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import sentry_sdk
 from dotenv import load_dotenv
 from sqlmodel import create_engine
 from telegram.ext import Application
+from telegram.request import HTTPXRequest
 
 from bot.dispatcher import init_dispatcher
 
@@ -50,9 +51,16 @@ engine = create_engine(dburi, echo=False)
 
 async def main():
     """Main function to run the bot."""
-    # Create application instance
-    # Note: PicklePersistence is removed in v20+, persistence needs different approach
-    application = Application.builder().token(API_TOKEN).build()
+    builder = Application.builder().token(API_TOKEN)
+    proxy = getenv("BOT_HTTPS_PROXY")
+    if proxy:
+        logger.info("Using outbound proxy for Telegram API")
+        builder = (
+            builder
+            .request(HTTPXRequest(proxy=proxy, connect_timeout=20.0, read_timeout=30.0))
+            .get_updates_request(HTTPXRequest(proxy=proxy, connect_timeout=20.0, read_timeout=40.0))
+        )
+    application = builder.build()
     
     # Setup dispatcher
     init_dispatcher(application, engine)


### PR DESCRIPTION
## Summary
- YC egress to `api.telegram.org` is blocked at the network level (RKN/cloud filter, confirmed via netshoot — TCP/443 times out from both pods and a neighbouring VM). This puts the bot into CrashLoopBackOff because `get_me()` during `Application.initialize()` can't complete, and even when keep-alive connections survive, every new `sendMessage` fails with `TimedOut`.
- Adds **optional** outbound proxy support: when `BOT_HTTPS_PROXY` is set, both the regular request client and the long-poll client use `HTTPXRequest(proxy=...)` with relaxed connect/read timeouts. When it isn't set, builder is unchanged (local dev and tests keep working as before).
- Wires the env var in the helm chart from `pidor-bot-secrets.bot_https_proxy` with `optional: true`, so the pod can start even if the secret key isn't present yet.

## Test plan
- [x] `python -c "import ast; ast.parse(open('main.py').read())"` — passes
- [x] `from telegram.request import HTTPXRequest; HTTPXRequest(proxy='http://x:y@127.0.0.1:3128')` — instantiates on installed PTB 21.7
- [ ] After merge + image build + rollout: pod starts without CrashLoop; log shows `Using outbound proxy for Telegram API`; `/pidor` in the chat replies as expected
- [ ] Verify with `BOT_HTTPS_PROXY` unset locally — bot still builds Application and connects directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)